### PR TITLE
Create rdssetup.rb

### DIFF
--- a/phpapp/recipes/rdssetup.rb
+++ b/phpapp/recipes/rdssetup.rb
@@ -1,0 +1,12 @@
+node[:deploy].each do |app_name, deploy|
+  execute "mysql-create-table" do
+    command "/usr/bin/mysql -h #{deploy[:database][:host]} -u#{deploy[:database][:username]} -p#{deploy[:database][:password]} #{deploy[:database][:database]} -e'CREATE TABLE #{node[:phpapp][:dbtable]}(
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    author VARCHAR(63) NOT NULL,
+    message TEXT,
+    PRIMARY KEY (id)
+  )'"
+    not_if "/usr/bin/mysql -h #{deploy[:database][:host]} -u#{deploy[:database][:username]} -p#{deploy[:database][:password]} #{deploy[:database][:database]} -e'SHOW TABLES' | grep #{node[:phpapp][:dbtable]}"
+    action :run
+  end
+end


### PR DESCRIPTION
Add a init database recipe that can run on the Application Layer, with the same function as the dbsetup but to init an RDS MySQL instance.

- This Recipe needs to run on the Application layer
- This Recipe should be removed from the deploy lifecycle after execution as you usually dont want to have database check processing at each App instance Deploy